### PR TITLE
Improve 'Perhaps Not' mimic button behaviour

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended',
+        'prettier',
     ],
     parser: '@typescript-eslint/parser',
     plugins: ['@typescript-eslint'],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "bracketSpacing": false,
+  "endOfLine": "crlf",
+  "printWidth": 120,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 4,
+  "useTabs": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "fl-small-mercies",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fl-small-mercies",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chrome": "^0.0.190",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
         "@typescript-eslint/parser": "^5.42.1",
         "eslint": "^8.27.0",
+        "eslint-config-prettier": "^8.8.0",
+        "prettier": "^2.8.8",
         "ts-loader": "^9.3.1",
         "typescript": "^4.8.4"
       }
@@ -1022,6 +1024,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1840,6 +1854,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -3208,6 +3237,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3819,6 +3855,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "prettier --plugin-search-dir . --check ./src && eslint ./src",
+    "format": "prettier --plugin-search-dir . --write ./src"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +15,8 @@
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.27.0",
+    "eslint-config-prettier": "^8.8.0",
+    "prettier": "^2.8.8",
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.4"
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,7 +118,11 @@ const SETTINGS_SCHEMA: SettingsSchema = [
                 default: false,
             },
             "top_exit_buttons": {
-                description: "Move 'Perhaps Not' button to the top in selected storylets.",
+                description: "Show 'Perhaps Not' button at the top in storylets that have 4 branches or more.",
+                default: false,
+            },
+            "top_exit_buttons_always": {
+                description: "└ Show the button regardless of the amount of branches in a storylet.",
                 default: false,
             }
         }

--- a/src/fixers/top_exit_buttons.ts
+++ b/src/fixers/top_exit_buttons.ts
@@ -103,7 +103,9 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
                 }
 
                 const otherButtons =
-                    exitButtonDiv.parentNode?.querySelectorAll("div[class*='media'][data-branch-id]") || [];
+                    exitButtonDiv.parentNode?.querySelectorAll(
+                        ".media--branch[data-branch-id] .storylet__buttons .button--primary"
+                    ) || [];
                 for (const otherBtn of otherButtons) {
                     otherBtn.addEventListener("click", () => this.mimicPanel?.remove());
                 }

--- a/src/fixers/top_exit_buttons.ts
+++ b/src/fixers/top_exit_buttons.ts
@@ -30,23 +30,23 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
     }
 
     createPerhapsNotMimic(): [HTMLElement, HTMLElement] {
-        const root = document.createElement('div');
+        const root = document.createElement("div");
 
-        const container = document.createElement('div');
-        container.classList.add('buttons', 'buttons--left', 'buttons--storylet-exit-options');
+        const container = document.createElement("div");
+        container.classList.add("buttons", "buttons--left", "buttons--storylet-exit-options");
         // Mark as mimic to prevent duplicates
-        container.classList.add('mimic-perhaps-not')
+        container.classList.add("mimic-perhaps-not");
 
-        const button = document.createElement('button');
-        button.classList.add('button', 'button--primary');
-        button.setAttribute('type', 'button');
+        const button = document.createElement("button");
+        button.classList.add("button", "button--primary");
+        button.setAttribute("type", "button");
 
-        const textSpan = document.createElement('span');
+        const textSpan = document.createElement("span");
 
-        const italics = document.createElement('i');
-        italics.classList.add('fa', 'fa-arrow-left');
+        const italics = document.createElement("i");
+        italics.classList.add("fa", "fa-arrow-left");
 
-        const text = document.createTextNode('Perhaps not');
+        const text = document.createTextNode("Perhaps not");
 
         root.appendChild(container);
 
@@ -61,7 +61,7 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
     }
 
     onNodeAdded(node: HTMLElement): void {
-        const exitButtonDiv = this.findNodeWithClass(node, 'buttons--storylet-exit-options');
+        const exitButtonDiv = this.findNodeWithClass(node, "buttons--storylet-exit-options");
 
         if (exitButtonDiv) {
             if (exitButtonDiv.classList.contains("mimic-perhaps-not")) {
@@ -73,7 +73,9 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
                 return;
             }
 
-            let originalPerhapsNot: HTMLElement | null = exitButtonDiv.querySelector("button > span > i[class*='fa-arrow-left']");
+            const originalPerhapsNot: HTMLElement | null = exitButtonDiv.querySelector(
+                "button > span > i[class*='fa-arrow-left']"
+            );
             const [mimicPanel, mimicButton] = this.createPerhapsNotMimic();
 
             if (originalPerhapsNot && mimicButton) {
@@ -86,7 +88,8 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
                     exitBtn.addEventListener("click", () => mimicPanel.remove());
                 }
 
-                const otherButtons = exitButtonDiv.parentElement?.querySelectorAll("div[class*='media'][data-branch-id]") || [];
+                const otherButtons =
+                    exitButtonDiv.parentElement?.querySelectorAll("div[class*='media'][data-branch-id]") || [];
                 for (const otherBtn of otherButtons) {
                     otherBtn.addEventListener("click", () => mimicPanel.remove());
                 }
@@ -103,6 +106,6 @@ export class TopExitButtonsFixer implements IMutationAwareFixer, IStateAware {
     linkState(stateController: GameStateController): void {
         stateController.onStoryletPhaseChanged((state) => {
             this.inSupportedStorylet = SUPPORTED_STORYLETS.includes(state.storyletId);
-        })
+        });
     }
 }


### PR DESCRIPTION
This pull request aims to accomplish the following:
- Introduce Prettier to unify formatting
- Fix "Perhaps Not" mimic button not being removed when switching equipment presets
- Fix "Perhaps Not" mimic button disappearing in nested storylets (where a branch leads into more branches)
- Fix "Perhaps Not" mimic button getting deleted when a user clicks on any storylet branch card. Now it will be deleted when a user clicks on the interaction button within branch card.
- Fix missing space between icon and text in the "Perhaps Not" mimic button
- Change the logic for creating mimic button. Instead of using whitelist now the mimic button is created whenever a storylet has 4 or more branches. This setting can be overriden to force the button to be created regardless of the amount of branches.