### PR TITLE
Make clear that two step confirmation branch is from extension

### DIFF
--- a/src/fixers/two_step_confirmations.ts
+++ b/src/fixers/two_step_confirmations.ts
@@ -94,17 +94,18 @@ const DANGEROUS_BRANCHES = [
     // 7702,  /* Your plant is singing */
 ];
 
-const CHOICE_HAS_BEEN_MADE_TEXT: string = "So be it.<br><br><b>You solemnly swear that you are aware what your " +
-                                            "actions may bring.</b>";
+const CHOICE_HAS_BEEN_MADE_TEXT: string = "So be it.<br><br><b><i>You solemnly swear that you are aware what your " + "actions may bring.</i></b>";
 
-const RAINCHECK_TEXT = "That's okay, no pressure, time is on your side. Rain check?<br><br>" +
-    "<b>You will be returned back to the storylet and will have one more chance to think it over.</b>";
+const RAINCHECK_TEXT =
+    "That's okay, no pressure, time is on your side. Rain check?<br><br>" +
+    "<b><i>You will be returned back to the storylet and will have one more chance to think it over.</i></b>";
 
-const JOHN_WICK_QUOTE_TEXT: string = "<i>" +
-    "\"Have you thought this through? I mean, chewed down to the bone? You got out once. You dip so much " +
+const JOHN_WICK_QUOTE_TEXT: string =
+    "<i>" +
+    '"Have you thought this through? I mean, chewed down to the bone? You got out once. You dip so much ' +
     "as a pinky back into this pond... you may well find something reaches out... and drags you back " +
-    "into its depths.\"</i><br><br><b>Branch that you chose is known to have very costly consequences, " +
-    "potentially irreversible ones. Please think twice about whether you are really committed to this path.</br>";
+    'into its depths."</i><br><br><b><i>[Fallen London Small Mercies] The branch that you chose is known to have very costly consequences, ' +
+    "potentially irreversible ones. Please think twice about whether you are really committed to this path. Select the yes option to confirm you want to do this.</i></br>";
 
 export class TwoStepConfirmationsFixer implements INetworkAware, IStateAware {
     private showConfirmations: boolean = true;
@@ -135,17 +136,13 @@ export class TwoStepConfirmationsFixer implements INetworkAware, IStateAware {
         });
 
         interceptor.onRequestSent("/api/storylet/choosebranch", (request) => {
-            const confirmationStorylet = new Storylet(CONFIRMATION_BRANCH_ID, "<i>Book of Wick</i>, John 41:53")
+            const confirmationStorylet = new Storylet(CONFIRMATION_BRANCH_ID, "[Small Mercies] <i>Book of Wick</i>, John 41:53")
                 .description(JOHN_WICK_QUOTE_TEXT)
                 .image("candleblack");
 
             if (DANGEROUS_BRANCHES.includes(request.branchId)) {
-                const yesBranch = new Branch(FAKE_BRANCH_ID_THRESHOLD + request.branchId, "YES.")
-                    .description(CHOICE_HAS_BEEN_MADE_TEXT)
-                    .image("well");
-                const noBranch = new Branch(CONFIRMATION_BRANCH_ID, "...No?")
-                    .description(RAINCHECK_TEXT)
-                    .image("eye");
+                const yesBranch = new Branch(FAKE_BRANCH_ID_THRESHOLD + request.branchId, "YES.").description(CHOICE_HAS_BEEN_MADE_TEXT).image("well");
+                const noBranch = new Branch(CONFIRMATION_BRANCH_ID, "...No?").description(RAINCHECK_TEXT).image("eye");
 
                 confirmationStorylet.addBranch(noBranch);
                 confirmationStorylet.addBranch(yesBranch);


### PR DESCRIPTION
Make it blindingly obvious that the two step confirmation storylet is from an extension and not an in-game feature; this led to a very confused discussion on Discord today. Also fixes a small grammar issue and the game instructions formatting