### PR TITLE
Fix StoryletChanged triggers

### DIFF
--- a/src/fixers/currency_displays.ts
+++ b/src/fixers/currency_displays.ts
@@ -172,11 +172,9 @@ export class MoreCurrencyDisplaysFixer implements IMutationAware, IStateAware {
         this.currencyToPredicate.set(
             "Assortment of Khaganian Coinage",
             new OrPredicate(
-                new OrPredicate(
-                    new IsInSetting(107955), // Khanate (Inner)
-                    new IsInSetting(107959) // Khanate (Copper Quarter)
-                ),
-                new IsInSetting(107975) // Irem
+                new IsInSetting(107955), // Khanate (Inner)
+                new IsInSetting(107959), // Khanate (Copper Quarter)
+                new IsInSetting(107975), // Irem
             )
         );
         this.currencyToPredicate.set(

--- a/src/game_state.ts
+++ b/src/game_state.ts
@@ -131,8 +131,6 @@ export class GameState {
 
     public actionsLeft = 0;
 
-    public storyletId = UNKNOWN;
-
     private qualities: Map<string, Map<string, Quality>> = new Map();
     private qualityIdMapping: Map<number, Quality> = new Map();
 
@@ -358,13 +356,18 @@ export class GameStateController {
             // @ts-ignore: There is hell and then there is writing types for external APIs
             const currentPhase = this.decodePhase(response.phase);
             if (currentPhase != this.state.storyletPhase) {
-                if (currentPhase == StoryletPhases.End) {
-                    // @ts-ignore: There is hell and then there is writing types for external APIs
-                    this.state.storyletId = response.endStorylet.event.id;
-                }
-
                 this.state.storyletPhase = currentPhase;
                 this.triggerListeners(StateChangeTypes.StoryletPhaseChanged);
+            }
+            if (response.endStorylet) {
+                // @ts-ignore: There is hell and then there is writing types for external APIs
+                this.state.currentStorylet = response.endStorylet.event;
+                this.triggerListeners(StateChangeTypes.StoryletChanged);
+            }
+            if (response.storylet) {
+                // @ts-ignore: There is hell and then there is writing types for external APIs
+                this.state.currentStorylet = response.storylet;
+                this.triggerListeners(StateChangeTypes.StoryletChanged);
             }
         }
 
@@ -403,6 +406,7 @@ export class GameStateController {
 
         this.state.currentStorylet = new UnknownStorylet();
         this.triggerListeners(StateChangeTypes.StoryletPhaseChanged);
+        this.triggerListeners(StateChangeTypes.StoryletChanged);
     }
 
     public parseStoryletResponse(response: any) {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -67,7 +67,10 @@ class IsInStorylet implements StateMatcher {
     }
 
     match(state: GameState): boolean {
-        return state.storyletPhase == StoryletPhases.In && state.storyletId === this.expectedStoryletId;
+        if (state.storyletPhase == StoryletPhases.In && 'id' in state.currentStorylet) {
+            return state.currentStorylet.id == this.expectedStoryletId;
+        }
+        return false;
     }
 }
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -6,20 +6,18 @@ interface StateMatcher {
 }
 
 class OrPredicate implements StateMatcher {
-    private readonly left: StateMatcher;
-    private readonly right: StateMatcher;
+    private readonly predicates: StateMatcher[];
 
-    constructor(left: StateMatcher, right: StateMatcher) {
-        this.left = left;
-        this.right = right;
+    constructor(...predicates: StateMatcher[]) {
+        this.predicates = predicates;
     }
 
     describe(): string {
-        return `Or(${this.left.describe()}, ${this.right.describe()})`;
+        return `Or(${this.predicates.map(p => p.describe()).join(', ')}})`;
     }
 
     match(state: GameState): boolean {
-        return this.left.match(state) || this.right.match(state);
+        return this.predicates.map(p => p.match(state)).some(b => b);
     }
 }
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -65,7 +65,7 @@ class IsInStorylet implements StateMatcher {
     }
 
     match(state: GameState): boolean {
-        if (state.storyletPhase == StoryletPhases.In && 'id' in state.currentStorylet) {
+        if ('id' in state.currentStorylet) {
             return state.currentStorylet.id == this.expectedStoryletId;
         }
         return false;


### PR DESCRIPTION
The `GameState.storyletId` variable is only sometimes updated and could thus not be relied on, and is furthermore redundant, as `GameState.currentStorylet` also contains the storylet ID. However, `currentStorylet` could also not be used, because it is not set on `choosebranch` results. Therefore, I suggest always setting `currentStorylet` correctly as per this PR.

This should fix the previously malfunctioning `IsInStorylet` matcher.